### PR TITLE
Prevent _shiftScroll from going past end of page

### DIFF
--- a/js/dataTables.rowReorder.js
+++ b/js/dataTables.rowReorder.js
@@ -625,7 +625,7 @@ $.extend( RowReorder.prototype, {
 				// Don't need to worry about setting scroll <0 or beyond the
 				// scroll bound as the browser will just reject that.
 				if ( scroll.windowVert ) {
-					document.body.scrollTop += scroll.windowVert;
+					document.body.scrollBottom -= scroll.windowVert;
 				}
 
 				// DataTables scrolling


### PR DESCRIPTION
Changes _shiftScroll to use document.body.scrollBottom to prevent the document's body from being scrolled past the end of the page when an item is being dragged.